### PR TITLE
Containerize proto generation and test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 .git
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # syntax = docker/dockerfile:experimental
-FROM node:12-alpine as base
+FROM node:12-buster-slim AS base
+WORKDIR /src
 ARG DOCKER_GITHUB_TOKEN
 ENV DOCKER_GITHUB_TOKEN=${DOCKER_GITHUB_TOKEN}
 COPY package.json .
@@ -10,6 +11,15 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn/v6 \
 
 COPY . .
 
-RUN yarn download-cli && \
-    chmod +x docker-linux-amd64 && \
-    yarn test
+FROM base AS test
+CMD ["yarn", "test"]
+VOLUME ["/var/run/docker.sock"]
+COPY --from=docker /usr/local/bin/docker /usr/local/bin/com.docker.cli
+RUN yarn download-cli
+
+FROM base AS download-protos
+RUN yarn download-protos
+RUN ./protos.sh
+
+FROM scratch AS protos
+COPY --from=download-protos /src/src /

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+ifeq (${DOCKER_GITHUB_TOKEN},)
+	@echo "DOCKER_GITHUB_TOKEN empty
+	@echo "Set with a GitHub token that has access to docker/compose-cli"
+	exit 1
+endif
+
+IMG?=node-sdk-test
+
+all: test
+
+.PHONY: test
+test:
+	@docker build --target test --tag ${IMG} --build-arg DOCKER_GITHUB_TOKEN .
+	docker run --rm \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		${IMG}
+
+.PHONY: protos
+protos:
+	@docker build --target protos --build-arg DOCKER_GITHUB_TOKEN --output ./src .


### PR DESCRIPTION
* To fetch protos and generate code, you can now run `make protos`
* To run tests, you can now run `make test`

**Note:** You will need a GitHub token that has access to docker/{api,compose-cli} set as `DOCKER_GITHUB_TOKEN`