### PR TITLE
Update protos - add `Environment` and `Command` options to `RunRequest`

### DIFF
--- a/src/protos/containers/v1/containers.proto
+++ b/src/protos/containers/v1/containers.proto
@@ -103,6 +103,8 @@ message RunRequest {
 	uint64 memory_limit = 6;
 	uint64 cpu_limit = 7;
 	string restart_policy_condition = 8;
+	repeated string command = 9;
+	repeated string environment = 10; 
 }
 
 message RunResponse {

--- a/src/protos/containers/v1/containers_pb.d.ts
+++ b/src/protos/containers/v1/containers_pb.d.ts
@@ -355,6 +355,16 @@ export class RunRequest extends jspb.Message {
     getRestartPolicyCondition(): string;
     setRestartPolicyCondition(value: string): RunRequest;
 
+    clearCommandList(): void;
+    getCommandList(): Array<string>;
+    setCommandList(value: Array<string>): RunRequest;
+    addCommand(value: string, index?: number): string;
+
+    clearEnvironmentList(): void;
+    getEnvironmentList(): Array<string>;
+    setEnvironmentList(value: Array<string>): RunRequest;
+    addEnvironment(value: string, index?: number): string;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): RunRequest.AsObject;
@@ -377,6 +387,8 @@ export namespace RunRequest {
         memoryLimit: number,
         cpuLimit: number,
         restartPolicyCondition: string,
+        commandList: Array<string>,
+        environmentList: Array<string>,
     }
 }
 

--- a/src/protos/containers/v1/containers_pb.js
+++ b/src/protos/containers/v1/containers_pb.js
@@ -2542,7 +2542,7 @@ proto.com.docker.api.protos.containers.v1.KillResponse.serializeBinaryToWriter =
  * @private {!Array<number>}
  * @const
  */
-proto.com.docker.api.protos.containers.v1.RunRequest.repeatedFields_ = [3,5];
+proto.com.docker.api.protos.containers.v1.RunRequest.repeatedFields_ = [3,5,9,10];
 
 
 
@@ -2583,7 +2583,9 @@ proto.com.docker.api.protos.containers.v1.RunRequest.toObject = function(include
     volumesList: (f = jspb.Message.getRepeatedField(msg, 5)) == null ? undefined : f,
     memoryLimit: jspb.Message.getFieldWithDefault(msg, 6, 0),
     cpuLimit: jspb.Message.getFieldWithDefault(msg, 7, 0),
-    restartPolicyCondition: jspb.Message.getFieldWithDefault(msg, 8, "")
+    restartPolicyCondition: jspb.Message.getFieldWithDefault(msg, 8, ""),
+    commandList: (f = jspb.Message.getRepeatedField(msg, 9)) == null ? undefined : f,
+    environmentList: (f = jspb.Message.getRepeatedField(msg, 10)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -2654,6 +2656,14 @@ proto.com.docker.api.protos.containers.v1.RunRequest.deserializeBinaryFromReader
     case 8:
       var value = /** @type {string} */ (reader.readString());
       msg.setRestartPolicyCondition(value);
+      break;
+    case 9:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addCommand(value);
+      break;
+    case 10:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addEnvironment(value);
       break;
     default:
       reader.skipField();
@@ -2735,6 +2745,20 @@ proto.com.docker.api.protos.containers.v1.RunRequest.serializeBinaryToWriter = f
   if (f.length > 0) {
     writer.writeString(
       8,
+      f
+    );
+  }
+  f = message.getCommandList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      9,
+      f
+    );
+  }
+  f = message.getEnvironmentList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      10,
       f
     );
   }
@@ -2925,6 +2949,80 @@ proto.com.docker.api.protos.containers.v1.RunRequest.prototype.getRestartPolicyC
  */
 proto.com.docker.api.protos.containers.v1.RunRequest.prototype.setRestartPolicyCondition = function(value) {
   return jspb.Message.setProto3StringField(this, 8, value);
+};
+
+
+/**
+ * repeated string command = 9;
+ * @return {!Array<string>}
+ */
+proto.com.docker.api.protos.containers.v1.RunRequest.prototype.getCommandList = function() {
+  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 9));
+};
+
+
+/**
+ * @param {!Array<string>} value
+ * @return {!proto.com.docker.api.protos.containers.v1.RunRequest} returns this
+ */
+proto.com.docker.api.protos.containers.v1.RunRequest.prototype.setCommandList = function(value) {
+  return jspb.Message.setField(this, 9, value || []);
+};
+
+
+/**
+ * @param {string} value
+ * @param {number=} opt_index
+ * @return {!proto.com.docker.api.protos.containers.v1.RunRequest} returns this
+ */
+proto.com.docker.api.protos.containers.v1.RunRequest.prototype.addCommand = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 9, value, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.com.docker.api.protos.containers.v1.RunRequest} returns this
+ */
+proto.com.docker.api.protos.containers.v1.RunRequest.prototype.clearCommandList = function() {
+  return this.setCommandList([]);
+};
+
+
+/**
+ * repeated string environment = 10;
+ * @return {!Array<string>}
+ */
+proto.com.docker.api.protos.containers.v1.RunRequest.prototype.getEnvironmentList = function() {
+  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 10));
+};
+
+
+/**
+ * @param {!Array<string>} value
+ * @return {!proto.com.docker.api.protos.containers.v1.RunRequest} returns this
+ */
+proto.com.docker.api.protos.containers.v1.RunRequest.prototype.setEnvironmentList = function(value) {
+  return jspb.Message.setField(this, 10, value || []);
+};
+
+
+/**
+ * @param {string} value
+ * @param {number=} opt_index
+ * @return {!proto.com.docker.api.protos.containers.v1.RunRequest} returns this
+ */
+proto.com.docker.api.protos.containers.v1.RunRequest.prototype.addEnvironment = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 10, value, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.com.docker.api.protos.containers.v1.RunRequest} returns this
+ */
+proto.com.docker.api.protos.containers.v1.RunRequest.prototype.clearEnvironmentList = function() {
+  return this.setEnvironmentList([]);
 };
 
 


### PR DESCRIPTION
Added `Environment` and `Command` options to the container run requests.