### PR TITLE
Syncing with compose-cli : can specify env vars and auto-remove option when running containers

### DIFF
--- a/src/protos/containers/v1/containers.proto
+++ b/src/protos/containers/v1/containers.proto
@@ -59,6 +59,7 @@ message HostConfig {
 	uint64 cpu_reservation = 3;
 	uint64 cpu_limit = 4;
 	string restart_policy = 5;
+	bool auto_remove = 6;
 }
 
 message InspectRequest {
@@ -110,7 +111,8 @@ message RunRequest {
 	uint64 cpu_limit = 7;
 	string restart_policy_condition = 8;
 	repeated string command = 9;
-	repeated string environment = 10; 
+	repeated string environment = 10;
+	bool auto_remove = 11;
 }
 
 message RunResponse {

--- a/src/protos/containers/v1/containers_pb.d.ts
+++ b/src/protos/containers/v1/containers_pb.d.ts
@@ -127,6 +127,9 @@ export class HostConfig extends jspb.Message {
     getRestartPolicy(): string;
     setRestartPolicy(value: string): HostConfig;
 
+    getAutoRemove(): boolean;
+    setAutoRemove(value: boolean): HostConfig;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): HostConfig.AsObject;
@@ -145,6 +148,7 @@ export namespace HostConfig {
         cpuReservation: number,
         cpuLimit: number,
         restartPolicy: string,
+        autoRemove: boolean,
     }
 }
 
@@ -397,6 +401,9 @@ export class RunRequest extends jspb.Message {
     setEnvironmentList(value: Array<string>): RunRequest;
     addEnvironment(value: string, index?: number): string;
 
+    getAutoRemove(): boolean;
+    setAutoRemove(value: boolean): RunRequest;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): RunRequest.AsObject;
@@ -421,6 +428,7 @@ export namespace RunRequest {
         restartPolicyCondition: string,
         commandList: Array<string>,
         environmentList: Array<string>,
+        autoRemove: boolean,
     }
 }
 

--- a/src/protos/containers/v1/containers_pb.js
+++ b/src/protos/containers/v1/containers_pb.js
@@ -1260,7 +1260,8 @@ proto.com.docker.api.protos.containers.v1.HostConfig.toObject = function(include
     memoryLimit: jspb.Message.getFieldWithDefault(msg, 2, 0),
     cpuReservation: jspb.Message.getFieldWithDefault(msg, 3, 0),
     cpuLimit: jspb.Message.getFieldWithDefault(msg, 4, 0),
-    restartPolicy: jspb.Message.getFieldWithDefault(msg, 5, "")
+    restartPolicy: jspb.Message.getFieldWithDefault(msg, 5, ""),
+    autoRemove: jspb.Message.getBooleanFieldWithDefault(msg, 6, false)
   };
 
   if (includeInstance) {
@@ -1316,6 +1317,10 @@ proto.com.docker.api.protos.containers.v1.HostConfig.deserializeBinaryFromReader
     case 5:
       var value = /** @type {string} */ (reader.readString());
       msg.setRestartPolicy(value);
+      break;
+    case 6:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setAutoRemove(value);
       break;
     default:
       reader.skipField();
@@ -1378,6 +1383,13 @@ proto.com.docker.api.protos.containers.v1.HostConfig.serializeBinaryToWriter = f
   if (f.length > 0) {
     writer.writeString(
       5,
+      f
+    );
+  }
+  f = message.getAutoRemove();
+  if (f) {
+    writer.writeBool(
+      6,
       f
     );
   }
@@ -1471,6 +1483,24 @@ proto.com.docker.api.protos.containers.v1.HostConfig.prototype.getRestartPolicy 
  */
 proto.com.docker.api.protos.containers.v1.HostConfig.prototype.setRestartPolicy = function(value) {
   return jspb.Message.setProto3StringField(this, 5, value);
+};
+
+
+/**
+ * optional bool auto_remove = 6;
+ * @return {boolean}
+ */
+proto.com.docker.api.protos.containers.v1.HostConfig.prototype.getAutoRemove = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 6, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.com.docker.api.protos.containers.v1.HostConfig} returns this
+ */
+proto.com.docker.api.protos.containers.v1.HostConfig.prototype.setAutoRemove = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 6, value);
 };
 
 
@@ -2818,7 +2848,8 @@ proto.com.docker.api.protos.containers.v1.RunRequest.toObject = function(include
     cpuLimit: jspb.Message.getFieldWithDefault(msg, 7, 0),
     restartPolicyCondition: jspb.Message.getFieldWithDefault(msg, 8, ""),
     commandList: (f = jspb.Message.getRepeatedField(msg, 9)) == null ? undefined : f,
-    environmentList: (f = jspb.Message.getRepeatedField(msg, 10)) == null ? undefined : f
+    environmentList: (f = jspb.Message.getRepeatedField(msg, 10)) == null ? undefined : f,
+    autoRemove: jspb.Message.getBooleanFieldWithDefault(msg, 11, false)
   };
 
   if (includeInstance) {
@@ -2897,6 +2928,10 @@ proto.com.docker.api.protos.containers.v1.RunRequest.deserializeBinaryFromReader
     case 10:
       var value = /** @type {string} */ (reader.readString());
       msg.addEnvironment(value);
+      break;
+    case 11:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setAutoRemove(value);
       break;
     default:
       reader.skipField();
@@ -2992,6 +3027,13 @@ proto.com.docker.api.protos.containers.v1.RunRequest.serializeBinaryToWriter = f
   if (f.length > 0) {
     writer.writeRepeatedString(
       10,
+      f
+    );
+  }
+  f = message.getAutoRemove();
+  if (f) {
+    writer.writeBool(
+      11,
       f
     );
   }
@@ -3256,6 +3298,24 @@ proto.com.docker.api.protos.containers.v1.RunRequest.prototype.addEnvironment = 
  */
 proto.com.docker.api.protos.containers.v1.RunRequest.prototype.clearEnvironmentList = function() {
   return this.setEnvironmentList([]);
+};
+
+
+/**
+ * optional bool auto_remove = 11;
+ * @return {boolean}
+ */
+proto.com.docker.api.protos.containers.v1.RunRequest.prototype.getAutoRemove = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 11, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.com.docker.api.protos.containers.v1.RunRequest} returns this
+ */
+proto.com.docker.api.protos.containers.v1.RunRequest.prototype.setAutoRemove = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 11, value);
 };
 
 


### PR DESCRIPTION

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**
* make protos

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
