### PR TITLE
Replace set-env, deprecated in GH actions. 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set env
-        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:11})
+        run: echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
       - uses: actions/setup-node@v1
         with:
           node-version: 12


### PR DESCRIPTION
Using [GH actions env files] (https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files)

Signed-off-by: Guillaume Tardif <guillaume.tardif@docker.com>

**What I did**

**Related issue**
https://github.com/docker/node-sdk/runs/1446714141

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
